### PR TITLE
Return "expandedKeys" on a tree node is selected

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -84,6 +84,7 @@ export interface TreeProps {
       node: NodeInstance;
       selectedNodes: DataNode[];
       nativeEvent: MouseEvent;
+      expandedKeys: Key[];
     },
   ) => void;
   onLoad?: (
@@ -542,7 +543,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
 
   onNodeSelect = (e, treeNode) => {
     let { selectedKeys } = this.state;
-    const { keyEntities } = this.state;
+    const { expandedKeys, keyEntities } = this.state;
     const { onSelect, multiple } = this.props;
     const { selected, eventKey } = treeNode.props;
     const targetSelected = !selected;
@@ -575,6 +576,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
         node: treeNode,
         selectedNodes,
         nativeEvent: e.nativeEvent,
+        expandedKeys;
       });
     }
   };


### PR DESCRIPTION
When set "autoExpandParent" to "true", someone need to implement the "conductExpandParent" repeatedly to get the complete "expandedKeys". Returning "expandedKeys" on a tree node is selected will be convenient to get "expandedKeys"!